### PR TITLE
Added to retrieve using value attribute, fallback.

### DIFF
--- a/OpenGraph.php
+++ b/OpenGraph.php
@@ -78,6 +78,15 @@ class OpenGraph implements Iterator
 				$key = strtr(substr($tag->getAttribute('property'), 3), '-', '_');
 				$page->_values[$key] = $tag->getAttribute('content');
 			}
+			
+			
+			//Added this if loop to retrieve description values from sites like the New York Times who have malformed it. 
+			if ($tag ->hasAttribute('value') && $tag->hasAttribute('property') &&
+			    strpos($tag->getAttribute('property'), 'og:') === 0) {
+				$key = strtr(substr($tag->getAttribute('property'), 3), '-', '_');
+				$page->_values[$key] = $tag->getAttribute('value');
+			}
+			
 		}
 
 		if (empty($page->_values)) { return false; }

--- a/OpenGraph.php
+++ b/OpenGraph.php
@@ -13,6 +13,9 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+   
+	Original can be found at https://github.com/scottmac/opengraph/blob/master/OpenGraph.php
+   
 */
 
 class OpenGraph implements Iterator
@@ -72,6 +75,8 @@ class OpenGraph implements Iterator
 
 		$page = new self();
 
+		$nonOgDescription = null;
+		
 		foreach ($tags AS $tag) {
 			if ($tag->hasAttribute('property') &&
 			    strpos($tag->getAttribute('property'), 'og:') === 0) {
@@ -79,15 +84,28 @@ class OpenGraph implements Iterator
 				$page->_values[$key] = $tag->getAttribute('content');
 			}
 			
-			
 			//Added this if loop to retrieve description values from sites like the New York Times who have malformed it. 
 			if ($tag ->hasAttribute('value') && $tag->hasAttribute('property') &&
 			    strpos($tag->getAttribute('property'), 'og:') === 0) {
 				$key = strtr(substr($tag->getAttribute('property'), 3), '-', '_');
 				$page->_values[$key] = $tag->getAttribute('value');
 			}
+			//Based on modifications at https://github.com/bashofmann/opengraph/blob/master/src/OpenGraph/OpenGraph.php
+			if ($tag->hasAttribute('name') && $tag->getAttribute('name') === 'description') {
+                $nonOgDescription = $tag->getAttribute('content');
+            }
 			
 		}
+		//Based on modifications at https://github.com/bashofmann/opengraph/blob/master/src/OpenGraph/OpenGraph.php
+		if (!isset($page->_values['title'])) {
+            $titles = $doc->getElementsByTagName('title');
+            if ($titles->length > 0) {
+                $page->_values['title'] = $titles->item(0)->textContent;
+            }
+        }
+        if (!isset($page->_values['description']) && $nonOgDescription) {
+            $page->_values['description'] = $nonOgDescription;
+        }
 
 		if (empty($page->_values)) { return false; }
 		


### PR DESCRIPTION
Added an extra if loop to retrieve description values from sites like New York Times who have malformed it by using value instead of content. See http://www.nytimes.com/2012/06/13/world/middleeast/violence-in-syria-continues-as-protesters-killed.html for an example of this bad code.

Also adapted code from https://github.com/bashofmann to create an easy fallback from pages without og tags to pull the title and description meta tags instead. 
