### PR TITLE
Replace file_get_contents() with cURL for speed/security

### DIFF
--- a/OpenGraph.php
+++ b/OpenGraph.php
@@ -47,7 +47,21 @@ class OpenGraph implements Iterator
    * @return OpenGraph
    */
 	static public function fetch($URI) {
-		return self::_parse(file_get_contents($URI));
+        $curl = curl_init($URI);
+
+        curl_setopt($curl, CURLOPT_FAILONERROR, true);
+        curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);
+        curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($curl, CURLOPT_TIMEOUT, 15);
+        curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, false);
+        curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);
+        curl_setopt($curl, CURLOPT_USERAGENT, $_SERVER['HTTP_USER_AGENT']);
+
+        $response = curl_exec($curl);
+
+        curl_close($curl);
+
+        return self::_parse($response);
 	}
 
   /**


### PR DESCRIPTION
- Replace the file_get_contents() call with a cURL call because cURL performs faster and
  file_get_contents() is disabled on a lot of servers for security
  reasons.
- I also notice cURL getting a lot of results back from
  websites where file_get_contents() didn't work.

Refs #4 
