### PR TITLE
Fallback to use image_src if ogp::image isn't set

### DIFF
--- a/OpenGraph.php
+++ b/OpenGraph.php
@@ -107,6 +107,20 @@ class OpenGraph implements Iterator
             $page->_values['description'] = $nonOgDescription;
         }
 
+        //Fallback to use image_src if ogp::image isn't set.
+        if (!isset($page->values['image'])) {
+            $domxpath = new DOMXPath($doc);
+            $elements = $domxpath->query("//link[@rel='image_src']");
+
+            if ($elements->length > 0) {
+                $domattr = $elements->item(0)->attributes->getNamedItem('href');
+                if ($domattr) {
+                    $page->_values['image'] = $domattr->value;
+                    $page->_values['image_src'] = $domattr->value;
+                }
+            }
+        }
+
 		if (empty($page->_values)) { return false; }
 		
 		return $page;


### PR DESCRIPTION
- Some websites (eg. imgur.com) don't have OGP tags but they do
  indicated an image associated with the page using image_src meta tag.
- Facebook.com's oEmbed also falls back on this if OGP data isn't available ([stackoverflow](http://stackoverflow.com/a/7623986/120210)).
