### PR TITLE
Fix DOMDocument Empty String PHP Warning

### DIFF
--- a/OpenGraph.php
+++ b/OpenGraph.php
@@ -61,7 +61,11 @@ class OpenGraph implements Iterator
 
         curl_close($curl);
 
-        return self::_parse($response);
+        if (!empty($response)) {
+            return self::_parse($response);
+        } else {
+            return false;
+        }
 	}
 
   /**


### PR DESCRIPTION
- Fix DOMDocument::loadHTML() throwing a PHP Warning if the result of
  the cURL call is an empty string. Checks that the result of the curl
  call isn't empty before passing it to the _parse() function.
