### PR TITLE
for corruption of text

### DIFF
--- a/OpenGraph.php
+++ b/OpenGraph.php
@@ -82,6 +82,7 @@ class OpenGraph implements Iterator
 		$old_libxml_error = libxml_use_internal_errors(true);
 
 		$doc = new DOMDocument();
+		$HTML = mb_convert_encoding($HTML, 'HTML-ENTITIES', 'auto');
 		$doc->loadHTML($HTML);
 		
 		libxml_use_internal_errors($old_libxml_error);


### PR DESCRIPTION
I added a line to solve garbage characters.

I saw garbage characters at some pages written in Japanese language.
I think it is caused by character code.
