### PR TITLE
Use the facebook user-agent instead of $_SERVER

### DIFF
--- a/OpenGraph.php
+++ b/OpenGraph.php
@@ -58,7 +58,7 @@ class OpenGraph implements Iterator
         curl_setopt($curl, CURLOPT_TIMEOUT, 15);
         curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, false);
         curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);
-        curl_setopt($curl, CURLOPT_USERAGENT, $_SERVER['HTTP_USER_AGENT']);
+        curl_setopt($curl, CURLOPT_USERAGENT, "facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)");
 
         $response = curl_exec($curl);
 


### PR DESCRIPTION
The $_SERVER globals may not be present (e.g. when using cronjobs, etc.). 
Using "facebookexternalhit" scraped pages will behave the same as to the original facebook scraper
