### PR TITLE
Update OpenGraph.php

### DIFF
--- a/OpenGraph.php
+++ b/OpenGraph.php
@@ -59,6 +59,9 @@ class OpenGraph implements Iterator
         curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, false);
         curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);
         curl_setopt($curl, CURLOPT_USERAGENT, $_SERVER['HTTP_USER_AGENT']);
+        //The following 2 set up lines work with sites like www.nytimes.com
+        curl_setopt($curl, CURLOPT_COOKIEFILE, "cookie.txt"); //you can change this path to whetever you want. 
+  	curl_setopt($curl, CURLOPT_COOKIEJAR, "cookie.txt"); //you can change this path to whetever you want. 
 
         $response = curl_exec($curl);
 


### PR DESCRIPTION
I added a fix for sites like www.nytimes.com because sites like it needs a cookie file in order to work. Otherwise the curl will retrieve a page that is not the actual page we want to read.

The change added 2 lines at the end of the curl request.
